### PR TITLE
Add netbase to enable ukbfetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Spiros Denaxas s.denaxas@gmail.com"
 
 ENV UKBURL=http://biobank.ctsu.ox.ac.uk/crystal/util
 
-RUN apt-get update && apt-get -y install wget
+RUN apt-get update && apt-get -y install wget netbase
 
 RUN for f in ukbunpack ukbfetch ukblink ukbgene ukbconv ukbmd5; do wget $UKBURL/$f -O /$f; chmod +x /$f ; done
 RUN wget -nd  biobank.ndph.ox.ac.uk/showcase/util/encoding.ukb


### PR DESCRIPTION
Resolves error "Servname not supported for ai_socktype" when runing ukbfetch